### PR TITLE
added parameter to deallocate query to list running VMs

### DIFF
--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -104,7 +104,7 @@ elif [[ "$1" == *"stop"* ]]; then
 
   # deallocating all VMs in workspaces
   # RG is in uppercase here (which is odd). Checking both cases for future compatability.
-  az vm list --query "[?(starts_with(resourceGroup,'${core_rg_name}-ws') || starts_with(resourceGroup,'${core_rg_name^^}-WS')) && powerState=='VM running'][name, resourceGroup]" -o tsv |
+  az vm list -d --query "[?(starts_with(resourceGroup,'${core_rg_name}-ws') || starts_with(resourceGroup,'${core_rg_name^^}-WS')) && powerState=='VM running'][name, resourceGroup]" -o tsv |
   while read -r vm_name rg_name; do
     echo "Deallocating VM ${vm_name} in ${rg_name}"
     az vm deallocate --resource-group "${rg_name}" --name "${vm_name}"


### PR DESCRIPTION
added parameter to deallocate query to list running VMs

# Resolves HASH_SIGN_FOLLOWED_BY_ISSUE_NUMBER

## What is being addressed

Describe the current behavior you are modifying. Please also remember to update any impacted documentation.

## How is this addressed

- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
- Update documentation
- Update CHANGELOG.md if needed
